### PR TITLE
MITM and Chained proxy support for HTTPS proxy 

### DIFF
--- a/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyConnection.java
@@ -377,7 +377,15 @@ abstract class ProxyConnection<I extends HttpObject> extends
             channel.config().setAutoRead(true);
         }
         SslHandler handler = new SslHandler(sslEngine);
-        pipeline.addFirst("ssl", handler);
+        if(pipeline.get("ssl") == null) {
+            pipeline.addFirst("ssl", handler);
+        } else {
+            // The second SSL handler is added to handle the case
+            // where the proxy (running as MITM) has to chain with
+            // another SSL enabled proxy. The second SSL handler
+            // is to perform SSL with the server.
+            pipeline.addAfter("ssl", "sslWithServer", handler);
+        }
         return handler.handshakeFuture();
     }
 

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -266,9 +266,10 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
 
             // The current HTTP Request can be null when this proxy is
             // negotiating a CONNECT request with a chained proxy 
-            // while it is running as a MITM.
+            // while it is running as a MITM. Since the response to a
+            // CONNECT request does not have any content, we return true.
             if(currentHttpRequest == null) {
-            	return true;
+                return true;
             } else {
                 return HttpMethod.HEAD.equals(currentHttpRequest.getMethod()) ?
                         true : super.isContentAlwaysEmpty(httpMessage);
@@ -646,22 +647,22 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
              * connection when we are negotiating connect (see readHttp()
              * in ProxyConnection). This cannot be ignored while we are
              * doing MITM + Chained Proxy because the HttpRequestEncoder
-             * of the Proxy to Server connection will be in an invalid state
+             * of the ProxyToServerConnection will be in an invalid state
              * when the next request is written. Writing the EmptyLastContent
              * resets its state.
              */
             if(isMitmEnabled()){
-            	ChannelFuture future = writeToChannel(initialRequest);
-            	future.addListener(new ChannelFutureListener() {
-					
-					@Override
-					public void operationComplete(ChannelFuture arg0) throws Exception {
-						if(arg0.isSuccess()){
-							writeToChannel(LastHttpContent.EMPTY_LAST_CONTENT);
-						}						
-					}
-				});
-            	return future;
+                ChannelFuture future = writeToChannel(initialRequest);
+                future.addListener(new ChannelFutureListener() {
+
+                    @Override
+                    public void operationComplete(ChannelFuture arg0) throws Exception {
+                        if(arg0.isSuccess()){
+                            writeToChannel(LastHttpContent.EMPTY_LAST_CONTENT);
+                        }
+                    }
+                });
+                return future;
             } else {
                 return writeToChannel(initialRequest);
             }

--- a/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
+++ b/src/main/java/org/littleshoot/proxy/impl/ProxyToServerConnection.java
@@ -568,10 +568,22 @@ public class ProxyToServerConnection extends ProxyConnection<HttpResponse> {
                         serverConnection.HTTPCONNECTWithChainedProxy);
             }
             if (isMitmEnabled()) {
-                connectionFlow
-                        .then(serverConnection.EncryptChannel(proxyServer.getMitmManager()
-                                .serverSslEngine(remoteAddress.getHostName(),
-                                        remoteAddress.getPort())))
+            	if(hasUpstreamChainedProxy()){
+            		// When MITM is enabled and when chained proxy is set up, remoteAddress
+            		// will be the chained proxy's address. So we use serverHostAndPort
+            		// which is the end server's address.
+                    HostAndPort parsedHostAndPort = HostAndPort.fromString(serverHostAndPort);
+            		
+                    connectionFlow.then(serverConnection.EncryptChannel(proxyServer.getMitmManager()
+                            .serverSslEngine(parsedHostAndPort.getHostText(),
+                            		parsedHostAndPort.getPort())));
+            	} else {
+                    connectionFlow.then(serverConnection.EncryptChannel(proxyServer.getMitmManager()
+                            .serverSslEngine(remoteAddress.getHostName(),
+                                    remoteAddress.getPort())));
+            	}
+            	
+            	connectionFlow
                         .then(clientConnection.RespondCONNECTSuccessful)
                         .then(serverConnection.MitmEncryptClientChannel);
             } else {

--- a/src/test/java/org/littleshoot/proxy/MitmWithBadClientAuthenticationTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithBadClientAuthenticationTCPChainedProxyTest.java
@@ -1,0 +1,54 @@
+package org.littleshoot.proxy;
+
+import static org.littleshoot.proxy.TransportProtocol.*;
+
+import javax.net.ssl.SSLEngine;
+
+import org.junit.Ignore;
+import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
+
+/**
+ * Tests that clients are authenticated and that if they're missing certs, we
+ * get an error.
+ */
+@Ignore
+public class MitmWithBadClientAuthenticationTCPChainedProxyTest extends
+        MitmWithChainedProxyTest {
+    private final SslEngineSource serverSslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_1.jks");
+    
+    private final SslEngineSource clientSslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_1.jks", false, false);
+
+    @Override
+    protected boolean expectBadGatewayForEverything() {
+        return true;
+    }
+    
+    @Override
+    protected HttpProxyServerBootstrap upstreamProxy() {
+        return super.upstreamProxy()
+                .withTransportProtocol(TCP)
+                .withSslEngineSource(serverSslEngineSource);
+    }
+
+    @Override
+    protected ChainedProxy newChainedProxy() {
+        return new BaseChainedProxy() {
+            @Override
+            public TransportProtocol getTransportProtocol() {
+                return TransportProtocol.TCP;
+            }
+
+            @Override
+            public boolean requiresEncryption() {
+                return true;
+            }
+
+            @Override
+            public SSLEngine newSslEngine() {
+                return clientSslEngineSource.newSslEngine();
+            }
+        };
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/MitmWithBadServerAuthenticationTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithBadServerAuthenticationTCPChainedProxyTest.java
@@ -1,0 +1,54 @@
+package org.littleshoot.proxy;
+
+import static org.littleshoot.proxy.TransportProtocol.*;
+
+import javax.net.ssl.SSLEngine;
+
+import org.junit.Ignore;
+import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
+
+/**
+ * Tests that servers are authenticated and that if they're missing certs, we
+ * get an error.
+ */
+@Ignore
+public class MitmWithBadServerAuthenticationTCPChainedProxyTest extends
+        BaseChainedProxyTest {
+    protected final SslEngineSource serverSslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_1.jks");
+    
+    protected final SslEngineSource clientSslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_2.jks");
+
+    @Override
+    protected boolean expectBadGatewayForEverything() {
+        return true;
+    }
+    
+    @Override
+    protected HttpProxyServerBootstrap upstreamProxy() {
+        return super.upstreamProxy()
+                .withTransportProtocol(TCP)
+                .withSslEngineSource(serverSslEngineSource);
+    }
+
+    @Override
+    protected ChainedProxy newChainedProxy() {
+        return new BaseChainedProxy() {
+            @Override
+            public TransportProtocol getTransportProtocol() {
+                return TransportProtocol.TCP;
+            }
+
+            @Override
+            public boolean requiresEncryption() {
+                return true;
+            }
+
+            @Override
+            public SSLEngine newSslEngine() {
+                return clientSslEngineSource.newSslEngine();
+            }
+        };
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/MitmWithChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithChainedProxyTest.java
@@ -17,7 +17,8 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 
 /**
- * Tests just a single basic proxy running as a man in the middle.
+  * Tests a proxy that runs as a MITM and which is chained with
+  * another proxy. 
  */
 public class MitmWithChainedProxyTest extends BaseChainedProxyTest {
     private Set<HttpMethod> requestPreMethodsSeen = new HashSet<HttpMethod>();

--- a/src/test/java/org/littleshoot/proxy/MitmWithClientAuthenticationNotRequiredTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithClientAuthenticationNotRequiredTCPChainedProxyTest.java
@@ -1,0 +1,48 @@
+package org.littleshoot.proxy;
+
+import static org.littleshoot.proxy.TransportProtocol.*;
+
+import javax.net.ssl.SSLEngine;
+
+import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
+
+/**
+ * Tests that when client authentication is not required, it doesn't matter what
+ * certs the client sends.
+ */
+public class MitmWithClientAuthenticationNotRequiredTCPChainedProxyTest extends
+        MitmWithChainedProxyTest {
+    private final SslEngineSource serverSslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_1.jks");
+
+    private final SslEngineSource clientSslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_1.jks", false, false);
+
+    @Override
+    protected HttpProxyServerBootstrap upstreamProxy() {
+        return super.upstreamProxy()
+                .withTransportProtocol(TCP)
+                .withSslEngineSource(serverSslEngineSource)
+                .withAuthenticateSslClients(false);
+    }
+
+    @Override
+    protected ChainedProxy newChainedProxy() {
+        return new BaseChainedProxy() {
+            @Override
+            public TransportProtocol getTransportProtocol() {
+                return TransportProtocol.TCP;
+            }
+
+            @Override
+            public boolean requiresEncryption() {
+                return true;
+            }
+
+            @Override
+            public SSLEngine newSslEngine() {
+                return clientSslEngineSource.newSslEngine();
+            }
+        };
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/MitmWithEncryptedTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithEncryptedTCPChainedProxyTest.java
@@ -1,0 +1,39 @@
+package org.littleshoot.proxy;
+
+import static org.littleshoot.proxy.TransportProtocol.*;
+
+import javax.net.ssl.SSLEngine;
+
+import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
+
+public class MitmWithEncryptedTCPChainedProxyTest extends MitmWithChainedProxyTest {
+    private final SslEngineSource sslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_1.jks");
+
+    @Override
+    protected HttpProxyServerBootstrap upstreamProxy() {
+        return super.upstreamProxy()
+                .withTransportProtocol(TCP)
+                .withSslEngineSource(sslEngineSource);
+    }
+
+    @Override
+    protected ChainedProxy newChainedProxy() {
+        return new BaseChainedProxy() {
+            @Override
+            public TransportProtocol getTransportProtocol() {
+                return TransportProtocol.TCP;
+            }
+
+            @Override
+            public boolean requiresEncryption() {
+                return true;
+            }
+
+            @Override
+            public SSLEngine newSslEngine() {
+                return sslEngineSource.newSslEngine();
+            }
+        };
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/MitmWithEncryptedUDTChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithEncryptedUDTChainedProxyTest.java
@@ -1,0 +1,39 @@
+package org.littleshoot.proxy;
+
+import static org.littleshoot.proxy.TransportProtocol.*;
+
+import javax.net.ssl.SSLEngine;
+
+import org.littleshoot.proxy.extras.SelfSignedSslEngineSource;
+
+public class MitmWithEncryptedUDTChainedProxyTest extends MitmWithChainedProxyTest {
+    private final SslEngineSource sslEngineSource = new SelfSignedSslEngineSource(
+            "chain_proxy_keystore_1.jks");
+
+    @Override
+    protected HttpProxyServerBootstrap upstreamProxy() {
+        return super.upstreamProxy()
+                .withTransportProtocol(UDT)
+                .withSslEngineSource(sslEngineSource);
+    }
+
+    @Override
+    protected ChainedProxy newChainedProxy() {
+        return new BaseChainedProxy() {
+            @Override
+            public TransportProtocol getTransportProtocol() {
+                return TransportProtocol.UDT;
+            }
+
+            @Override
+            public boolean requiresEncryption() {
+                return true;
+            }
+
+            @Override
+            public SSLEngine newSslEngine() {
+                return sslEngineSource.newSslEngine();
+            }
+        };
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/MitmWithUnencryptedTCPChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithUnencryptedTCPChainedProxyTest.java
@@ -1,0 +1,26 @@
+package org.littleshoot.proxy;
+
+import static org.littleshoot.proxy.TransportProtocol.*;
+
+public class MitmWithUnencryptedTCPChainedProxyTest extends MitmWithChainedProxyTest {
+    @Override
+    protected HttpProxyServerBootstrap upstreamProxy() {
+        return super.upstreamProxy()
+                .withTransportProtocol(TCP);
+    }
+
+    @Override
+    protected ChainedProxy newChainedProxy() {
+        return new BaseChainedProxy() {
+            @Override
+            public TransportProtocol getTransportProtocol() {
+                return TransportProtocol.TCP;
+            }
+
+            @Override
+            public boolean requiresEncryption() {
+                return false;
+            }
+        };
+    }
+}

--- a/src/test/java/org/littleshoot/proxy/MitmWithUnencryptedUDTChainedProxyTest.java
+++ b/src/test/java/org/littleshoot/proxy/MitmWithUnencryptedUDTChainedProxyTest.java
@@ -1,0 +1,26 @@
+package org.littleshoot.proxy;
+
+import static org.littleshoot.proxy.TransportProtocol.*;
+
+public class MitmWithUnencryptedUDTChainedProxyTest extends MitmWithChainedProxyTest {
+    @Override
+    protected HttpProxyServerBootstrap upstreamProxy() {
+        return super.upstreamProxy()
+                .withTransportProtocol(UDT);
+    }
+
+    @Override
+    protected ChainedProxy newChainedProxy() {
+        return new BaseChainedProxy() {
+            @Override
+            public TransportProtocol getTransportProtocol() {
+                return TransportProtocol.UDT;
+            }
+
+            @Override
+            public boolean requiresEncryption() {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Also, I made a fix to use the correct host and port to select the SSLEngine for SSL with the end server. Without this fix, HostNameMitmManager and CertificateSniffingMitmManager were failing for me in these examples - 

1) https://github.com/MediumOne/littleproxy-example/blob/master/src/main/java/m1/learning/littleproxy/example/CertSniffingMitmWithChainedProxy.java

2) https://github.com/MediumOne/littleproxy-example/blob/master/src/main/java/m1/learning/littleproxy/example/CertSniffingMitmWithChainedHttpsProxy.java
